### PR TITLE
Introduce Playbook for deploying LEMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the following line to `/etc/hosts`
 `192.168.121.223 example.com`
 
 ### Windows:
-Add the following line to `C:\Windows\drivers\etc\hosts`:
+Add the following line to `C:\Windows\System32\drivers\etc\hosts`:
 
 `192.168.121.223 example.com`
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # simple-wp-hosting
+
+## Overview
+Automatic deployment of LEMP stack with (mostly) default configuration.
+
+## Common usage:
+Run
+```
+ansible-galaxy install geerlingguy.php geerlingguy.nginx geerlingguy.mysql
+ansible-playbook playbook.yml
+```
+## Usage with Vagrant: 
+Run `vagrant up`
+Run `vagrant ssh`
+![ip a](https://khomutsky.com/files/images/vagrant_ip.png "Interfaces")
+Copy IP address of interface number 2, and place into `hosts` file.
+### GNU/Linux, Unix and OS X:
+
+Add the following line to `/etc/hosts`
+
+`192.168.121.223 example.com`
+
+### Windows:
+Add the following line to `C:\Windows\drivers\etc\hosts`:
+
+`192.168.121.223 example.com`
+
+Replace `192.168.121.223` with IP you copied in previous step.
+Go to example.com. In case of successful provision you should get php info.
+![phpinfo](https://khomutsky.com/files/images/phpinfo.png "PHPInfo")
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## Overview
 Automatic deployment of LEMP stack with (mostly) default configuration.
 
+## Compatibility
+Debian stretch
+
 ## Common usage:
 Run
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "debian/stretch64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  #config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "playbook.yml"
+    ansible.become = true
+end
+end

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,54 @@
+---
+- name: Install LEMP for wordpress
+  hosts: all
+  roles:
+  - geerlingguy.nginx
+  - geerlingguy.php
+  - geerlingguy.mysql
+  vars:
+    mysql_enabled_on_startup: yes
+    mysql_databases:
+      - name: wordpress
+    mysql_users:
+      - name: wordpress
+        password: wordpress
+        priv: "wordpress.*:ALL"
+    nginx_vhosts:
+      - listen: "80"
+        server_name: "example.com"
+        server_name_redirect: "www.example.com"
+        root: "/var/www/example.com"
+        index: "index.php"
+        state: "present"
+        template: "{{ nginx_vhost_template }}"
+        filename: "example.com.conf"
+        extra_parameters: |
+          location ~ \.php$ {
+              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+              fastcgi_index index.php;
+              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+              include fastcgi_params;
+          }
+    php_enable_php_fpm: true
+    php_fpm_listen: /run/php/php7.0-fpm.sock
+
+- name: Deploy php application (phpinfo)
+  hosts: all
+  tasks:
+  - name: create webroot
+    file:
+      path: /var/www/example.com
+      state: directory
+      mode: 0770
+      owner: www-data
+      group: vagrant
+  - name: place phpinfo
+    lineinfile:
+      path: /var/www/example.com/index.php
+      line: '<?php phpinfo();'
+      create: yes
+      owner: www-data
+      group: vagrant
+      mode: 0770
+


### PR DESCRIPTION
The playbook provisions LEMP stack and phpinfo on GNU/Linux operating systems (tested on Debian).
You can test the playbook via Vagrant. See accompanying README.md for details.